### PR TITLE
[Bug fix] removeSelector element for VRT was missing .

### DIFF
--- a/.github/tests/vrt/template-paths.js
+++ b/.github/tests/vrt/template-paths.js
@@ -31,7 +31,7 @@ scenarioPaths.paths = [
     },
     {
         "label": "Home",
-        "removeSelectors": ["egg"]
+        "removeSelectors": [".egg"]
     },
 ];
 


### PR DESCRIPTION
## Description
The animated egg on the Wagtail homepage causes the VRT to fail (see #66 ). However, the selector we added was missing the preceding `.`. 

## Related Issue
#66 

## Motivation and Context
Resolve false negative tests

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the contribution guide
- [x] I have created an issue following the issue guide
- [x] My code follows the code style of this project.
